### PR TITLE
Update to newer Orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,5 +10,4 @@ workflows:
               ignore: "master"
 
 orbs:
-  pfe: stevector/pantheon-frontend@0.0.2
-  # pfe: stevector/pantheon-frontend@dev:header-in-sync
+  pfe: stevector/pantheon-frontend@0.1.0


### PR DESCRIPTION
@omero With this new Orb version (https://github.com/stevector/frontend-orb/releases/tag/0.1.0) you should be able to remove the global variable for Google Cloud (except the auth key).